### PR TITLE
Fix autoAdjustAmount in FundingTransaction and accept smal fee tolereance

### DIFF
--- a/src/transaction/builders/FundingTransaction.ts
+++ b/src/transaction/builders/FundingTransaction.ts
@@ -31,11 +31,12 @@ export class FundingTransaction extends TransactionBuilder<TransactionType.FUNDI
 
         this.addInputsFromUTXO();
 
-        // When autoAdjustAmount is enabled and the amount would leave no room for fees,
-        // estimate the fee first and reduce the output amount accordingly.
-        if (this.autoAdjustAmount && this.amount >= this.totalInputAmount) {
-            // Add temporary outputs matching the ACTUAL final transaction shape
-            // so the fee estimate accounts for the real vsize.
+        // When autoAdjustAmount is enabled, estimate the fee against the final
+        // transaction shape and reduce the output amount whenever amount + fee
+        // would exceed the total input. This covers both the send-max case
+        // (amount == totalInput) and the near-total case where amount alone fits
+        // but leaves no room for the requested feeRate.
+        if (this.autoAdjustAmount) {
             const numOutputs = this.splitInputsInto > 1 ? this.splitInputsInto : 1;
             const perOutputAmount = this.amount / BigInt(numOutputs);
 
@@ -59,27 +60,27 @@ export class FundingTransaction extends TransactionBuilder<TransactionType.FUNDI
                 }
             }
 
-            // If a note is present, add a temporary OP_RETURN since it affects vsize.
             if (this.note) {
                 this.addOPReturn(this.note);
             }
 
             const estimatedFee = await this.estimateTransactionFees();
 
-            // Remove all temporary outputs.
             const tempCount = numOutputs + (this.note ? 1 : 0);
             for (let i = 0; i < tempCount; i++) {
                 this.outputs.pop();
             }
 
-            const adjustedAmount = this.totalInputAmount - estimatedFee;
-            if (adjustedAmount < TransactionBuilder.MINIMUM_DUST) {
-                throw new Error(
-                    `Insufficient funds: after deducting fee of ${estimatedFee} sats, remaining amount ${adjustedAmount} sats is below minimum dust`,
-                );
-            }
+            if (this.amount + estimatedFee > this.totalInputAmount) {
+                const adjustedAmount = this.totalInputAmount - estimatedFee;
+                if (adjustedAmount < TransactionBuilder.MINIMUM_DUST) {
+                    throw new Error(
+                        `Insufficient funds: after deducting fee of ${estimatedFee} sats, remaining amount ${adjustedAmount} sats is below minimum dust`,
+                    );
+                }
 
-            this.amount = adjustedAmount;
+                this.amount = adjustedAmount;
+            }
         }
 
         // Add the primary output(s) first

--- a/src/transaction/builders/FundingTransaction.ts
+++ b/src/transaction/builders/FundingTransaction.ts
@@ -33,7 +33,7 @@ export class FundingTransaction extends TransactionBuilder<TransactionType.FUNDI
 
         // When autoAdjustAmount is enabled and the amount would leave no room for fees,
         // estimate the fee first and reduce the output amount accordingly.
-        if (this.autoAdjustAmount && this.amount >= this.totalInputAmount) {
+        if (this.autoAdjustAmount) {
             // Add temporary outputs matching the ACTUAL final transaction shape
             // so the fee estimate accounts for the real vsize.
             const numOutputs = this.splitInputsInto > 1 ? this.splitInputsInto : 1;
@@ -64,22 +64,29 @@ export class FundingTransaction extends TransactionBuilder<TransactionType.FUNDI
                 this.addOPReturn(this.note);
             }
 
+            // If the transaction need an anchor output, add a temporary anchor since it affects vsize
+            if (this.anchor) {
+                this.addAnchor();
+            }
+
             const estimatedFee = await this.estimateTransactionFees();
 
             // Remove all temporary outputs.
-            const tempCount = numOutputs + (this.note ? 1 : 0);
+            const tempCount = numOutputs + (this.note ? 1 : 0) + (this.anchor ? 1 : 0);
             for (let i = 0; i < tempCount; i++) {
                 this.outputs.pop();
             }
 
-            const adjustedAmount = this.totalInputAmount - estimatedFee;
-            if (adjustedAmount < TransactionBuilder.MINIMUM_DUST) {
-                throw new Error(
-                    `Insufficient funds: after deducting fee of ${estimatedFee} sats, remaining amount ${adjustedAmount} sats is below minimum dust`,
-                );
-            }
+            if (this.amount + estimatedFee >= this.totalInputAmount) {
+                const adjustedAmount = this.totalInputAmount - estimatedFee;
+                if (adjustedAmount < TransactionBuilder.MINIMUM_DUST) {
+                    throw new Error(
+                        `Insufficient funds: after deducting fee of ${estimatedFee} sats, remaining amount ${adjustedAmount} sats is below minimum dust`,
+                    );
+                }
 
-            this.amount = adjustedAmount;
+                this.amount = adjustedAmount;
+            }
         }
 
         // Add the primary output(s) first
@@ -87,10 +94,7 @@ export class FundingTransaction extends TransactionBuilder<TransactionType.FUNDI
             this.splitInputs(this.amount);
         } else if (this.isPubKeyDestination) {
             const toHexClean = this.to.startsWith('0x') ? this.to.slice(2) : this.to;
-            const pubKeyScript: Script = script.compile([
-                fromHex(toHexClean),
-                opcodes.OP_CHECKSIG,
-            ]);
+            const pubKeyScript: Script = script.compile([fromHex(toHexClean), opcodes.OP_CHECKSIG]);
 
             this.addOutput({
                 value: toSatoshi(this.amount),

--- a/src/transaction/builders/TransactionBuilder.ts
+++ b/src/transaction/builders/TransactionBuilder.ts
@@ -46,6 +46,11 @@ export const MINIMUM_AMOUNT_REWARD: bigint = 330n; //540n;
 export const MINIMUM_AMOUNT_CA: bigint = 297n;
 export const ANCHOR_SCRIPT = fromHex('51024e73');
 
+// Tolerance for fees
+// Less than 1 is percentage: 0.10 equals +- 10%
+// 1 or more is satoshis, 5 equals +- 5 sat
+export const TOLERANCE = 1;
+
 /**
  * Allows to build a transaction like you would on Ethereum.
  * @description The transaction builder class
@@ -804,17 +809,31 @@ export abstract class TransactionBuilder<T extends TransactionType> extends Twea
                 );
             }
 
-            if (this.totalInputAmount <= amountSpent) {
-                throw new Error(
-                    `Insufficient funds: need ${amountSpent + feeWithoutChange} sats but only have ${this.totalInputAmount} sats`,
-                );
-            }
-
             if (expectRefund && sendBackAmount < 0n) {
                 throw new Error(
                     `Insufficient funds: need at least ${-sendBackAmount} more sats to cover fees.`,
                 );
             }
+        }
+
+        const amountNeeded = amountSpent + this.transactionFee;
+
+        const tolerance: bigint =
+            TOLERANCE < 1
+                ? BigInt(Math.ceil(Number(this.transactionFee) * TOLERANCE))
+                : BigInt(Math.ceil(TOLERANCE));
+
+        if (this.totalInputAmount < amountSpent) {
+            throw new Error(
+                `Insufficient funds: need ${amountNeeded} sats but only have ${this.totalInputAmount} sats`,
+            );
+        }
+
+        if (this.totalInputAmount < amountNeeded - tolerance) {
+            const missingAmount = amountNeeded - this.totalInputAmount - tolerance;
+            throw new Error(
+                `Insufficient funds: need at least ${missingAmount} more sats to cover fees.2`,
+            );
         }
 
         if (this.debugFees) {

--- a/src/transaction/builders/TransactionBuilder.ts
+++ b/src/transaction/builders/TransactionBuilder.ts
@@ -387,11 +387,28 @@ export abstract class TransactionBuilder<T extends TransactionType> extends Twea
      * @throws {Error} - If something went wrong
      */
     public async signPSBT(): Promise<Psbt> {
-        if (await this.signTransaction()) {
-            return this.transaction;
+        if (!this.utxos.length) throw new Error('No UTXOs specified');
+
+        if (
+            this.to &&
+            !this.isPubKeyDestination &&
+            !EcKeyPair.verifyContractAddress(this.to, this.network)
+        ) {
+            throw new Error(
+                'Invalid contract address. The contract address must be a taproot address.',
+            );
         }
 
-        throw new Error('Could not sign transaction');
+        if (this.signed) throw new Error('Transaction is already signed');
+        this.signed = true;
+
+        await this.buildTransaction();
+
+        const built = await this.internalBuildTransaction(this.transaction);
+        if (!built) throw new Error('Could not sign transaction');
+        if (this.regenerated) throw new Error('Transaction was regenerated');
+
+        return this.transaction;
     }
 
     /**
@@ -807,6 +824,16 @@ export abstract class TransactionBuilder<T extends TransactionType> extends Twea
             if (this.totalInputAmount <= amountSpent) {
                 throw new Error(
                     `Insufficient funds: need ${amountSpent + feeWithoutChange} sats but only have ${this.totalInputAmount} sats`,
+                );
+            }
+
+            // No change output: the leftover (totalInput - amountSpent) becomes
+            // the on-chain fee. If it would undershoot the fee implied by feeRate,
+            // throw rather than silently broadcast an underpaid transaction.
+            const leftover = this.totalInputAmount - amountSpent;
+            if (leftover < feeWithoutChange) {
+                throw new Error(
+                    `Insufficient funds for fee: need ${feeWithoutChange} sats at feeRate ${this.feeRate}, but only ${leftover} sats remain after outputs.`,
                 );
             }
 

--- a/src/transaction/builders/TransactionBuilder.ts
+++ b/src/transaction/builders/TransactionBuilder.ts
@@ -832,7 +832,7 @@ export abstract class TransactionBuilder<T extends TransactionType> extends Twea
         if (this.totalInputAmount < amountNeeded - tolerance) {
             const missingAmount = amountNeeded - this.totalInputAmount - tolerance;
             throw new Error(
-                `Insufficient funds: need at least ${missingAmount} more sats to cover fees.2`,
+                `Insufficient funds: need at least ${missingAmount} more sats to cover fees.`,
             );
         }
 

--- a/src/transaction/offline/OfflineTransactionManager.ts
+++ b/src/transaction/offline/OfflineTransactionManager.ts
@@ -1,4 +1,4 @@
-import { fromHex, Psbt, type PsbtInput, type Signer, toHex } from '@btc-vision/bitcoin';
+import { fromHex, Psbt, type PsbtInput, type Signer, toHex, toXOnly } from '@btc-vision/bitcoin';
 import { type UniversalSigner } from '@btc-vision/ecpair';
 import { TransactionType } from '../enums/TransactionType.js';
 import { TransactionBuilder } from '../builders/TransactionBuilder.js';
@@ -14,6 +14,21 @@ import type {
     IInteractionParameters,
     ITransactionParameters,
 } from '../interfaces/ITransactionParameters.js';
+import { CSVMultisigProvider } from '../mineable/CSVMultisigProvider.js';
+
+/**
+ * Per-input CSV multisig signing status.
+ */
+export interface CSVMultisigInputStatus {
+    /** PSBT input index */
+    readonly inputIndex: number;
+    /** Threshold required to spend this input */
+    readonly required: number;
+    /** Number of distinct cosigner signatures collected so far */
+    readonly collected: number;
+    /** Hex-encoded x-only pubkeys of the cosigners that have signed */
+    readonly signers: string[];
+}
 
 /**
  * Export options for offline transaction signing
@@ -625,5 +640,180 @@ export class OfflineTransactionManager {
         };
 
         return TransactionSerializer.toBase64(newState);
+    }
+
+    /**
+     * Inspect collaborative signing progress on all CSV multisig inputs.
+     * Returns an empty array when no partial PSBT has been produced yet.
+     */
+    public static csvMultisigGetStatus(serializedState: string): CSVMultisigInputStatus[] {
+        const state = TransactionSerializer.fromBase64(serializedState);
+        if (!state.partialPsbtBase64) return [];
+
+        const network = TransactionReconstructor['nameToNetwork'](state.baseParams.networkName);
+        const psbt = Psbt.fromBase64(state.partialPsbtBase64, { network });
+        return this.computeCSVMultisigStatus(state, psbt, network);
+    }
+
+    /**
+     * Add the given signer's contribution to every CSV multisig input it can sign.
+     * No-op for inputs whose tapscript does not contain the signer's x-only pubkey.
+     *
+     * First call (no partial PSBT yet) builds the PSBT from the funding params
+     * using the provided signer as the builder's signer. Subsequent calls load
+     * the carried PSBT and add the signer's tapScriptSig where applicable.
+     */
+    public static async addCSVMultisigSignature(
+        serializedState: string,
+        signer: Signer | UniversalSigner,
+    ): Promise<{
+        state: string;
+        final: boolean;
+        perInput: CSVMultisigInputStatus[];
+    }> {
+        const state = TransactionSerializer.fromBase64(serializedState);
+        const network = TransactionReconstructor['nameToNetwork'](state.baseParams.networkName);
+
+        let psbt: Psbt;
+
+        if (state.partialPsbtBase64) {
+            psbt = Psbt.fromBase64(state.partialPsbtBase64, { network });
+            this.addSignerToCSVInputs(psbt, signer, network);
+        } else {
+            const builder = this.importForSigning(serializedState, { signer });
+            psbt = await builder.signPSBT();
+            // Best-effort: ensure the signer's contribution is recorded on every
+            // CSV input where they're a cosigner (the builder already attempts
+            // this, but this guards against builds that bailed early).
+            this.addSignerToCSVInputs(psbt, signer, network);
+        }
+
+        const perInput = this.computeCSVMultisigStatus(state, psbt, network);
+        const final = perInput.length > 0 && perInput.every((s) => s.collected >= s.required);
+
+        const newState: ISerializableTransactionState = {
+            ...state,
+            partialPsbtBase64: psbt.toBase64(),
+        };
+
+        return {
+            state: TransactionSerializer.toBase64(newState),
+            final,
+            perInput,
+        };
+    }
+
+    /**
+     * Finalize every CSV multisig input on the partial PSBT and extract the
+     * raw transaction hex. Throws if any input is still below its threshold.
+     */
+    public static csvMultisigFinalize(serializedState: string): string {
+        const state = TransactionSerializer.fromBase64(serializedState);
+        if (!state.partialPsbtBase64) {
+            throw new Error('No partial PSBT in state — call addCSVMultisigSignature first');
+        }
+
+        const network = TransactionReconstructor['nameToNetwork'](state.baseParams.networkName);
+        const psbt = Psbt.fromBase64(state.partialPsbtBase64, { network });
+
+        for (let i = 0; i < psbt.data.inputs.length; i++) {
+            const input = psbt.data.inputs[i] as PsbtInput;
+            if (!input.tapLeafScript || input.tapLeafScript.length === 0) continue;
+
+            const leaf = input.tapLeafScript[0];
+            if (!leaf) continue;
+
+            const addr = CSVMultisigProvider.deriveAddressFromTapscript(leaf.script, network);
+            if (!addr) continue;
+
+            CSVMultisigProvider.finalizePsbtInput(psbt, i, network, addr);
+        }
+
+        return psbt.extractTransaction(true, true).toHex();
+    }
+
+    /**
+     * Sign every CSV multisig input whose tapscript contains the signer's
+     * x-only pubkey and does not yet carry a signature from that pubkey.
+     */
+    private static addSignerToCSVInputs(
+        psbt: Psbt,
+        signer: Signer | UniversalSigner,
+        network: import('@btc-vision/bitcoin').Network,
+    ): void {
+        const signerXOnly = toXOnly(signer.publicKey);
+        const signerXOnlyHex = toHex(signerXOnly);
+
+        for (let i = 0; i < psbt.data.inputs.length; i++) {
+            const input = psbt.data.inputs[i] as PsbtInput;
+            if (!input.tapLeafScript || input.tapLeafScript.length === 0) continue;
+
+            const leaf = input.tapLeafScript[0];
+            if (!leaf) continue;
+
+            const addr = CSVMultisigProvider.deriveAddressFromTapscript(leaf.script, network);
+            if (!addr) continue;
+
+            const isCosigner = addr.config.pubkeys.some(
+                (pk) => toHex(pk as Uint8Array) === signerXOnlyHex,
+            );
+            if (!isCosigner) continue;
+
+            const alreadySigned = (input.tapScriptSig ?? []).some(
+                (s) => toHex(s.pubkey) === signerXOnlyHex,
+            );
+            if (alreadySigned) continue;
+
+            psbt.signTaprootInput(i, signer);
+        }
+    }
+
+    /**
+     * Build per-input status for every CSV multisig input.
+     *
+     * Walks state.utxos so we can detect CSV multisig inputs even after the
+     * builder has already finalized them (which clears tapLeafScript). For
+     * partially-signed inputs the signers list reflects collected tapScriptSig
+     * entries; for finalized inputs collected is set to the threshold.
+     */
+    private static computeCSVMultisigStatus(
+        state: ISerializableTransactionState,
+        psbt: Psbt,
+        network: import('@btc-vision/bitcoin').Network,
+    ): CSVMultisigInputStatus[] {
+        const result: CSVMultisigInputStatus[] = [];
+
+        for (let i = 0; i < state.utxos.length; i++) {
+            const utxo = state.utxos[i];
+            if (!utxo?.witnessScript) continue;
+
+            const tapscript = fromHex(utxo.witnessScript);
+            const addr = CSVMultisigProvider.deriveAddressFromTapscript(tapscript, network);
+            if (!addr) continue;
+
+            const input = psbt.data.inputs[i] as PsbtInput | undefined;
+            if (!input) continue;
+
+            if (input.finalScriptWitness) {
+                // Already finalized — by construction it carried >= threshold sigs.
+                result.push({
+                    inputIndex: i,
+                    required: addr.config.threshold,
+                    collected: addr.config.threshold,
+                    signers: [],
+                });
+                continue;
+            }
+
+            const tapSigs = input.tapScriptSig ?? [];
+            result.push({
+                inputIndex: i,
+                required: addr.config.threshold,
+                collected: tapSigs.length,
+                signers: tapSigs.map((s) => toHex(s.pubkey)),
+            });
+        }
+
+        return result;
     }
 }

--- a/src/transaction/offline/TransactionSerializer.ts
+++ b/src/transaction/offline/TransactionSerializer.ts
@@ -67,6 +67,9 @@ export class TransactionSerializer {
         // Write precomputed data
         this.writePrecomputedData(writer, state.precomputedData);
 
+        // v2: partial PSBT (empty string when absent)
+        writer.writeStringWithLength(state.partialPsbtBase64 ?? '');
+
         // Get buffer and calculate checksum
         const dataBuffer = writer.getBuffer();
         const checksum = this.calculateChecksum(dataBuffer);
@@ -128,6 +131,13 @@ export class TransactionSerializer {
         // Read precomputed data
         const precomputedData = this.readPrecomputedData(reader);
 
+        // v2+: partial PSBT (collaborative signing carryover)
+        let partialPsbtBase64: string | undefined;
+        if (header.formatVersion >= 2) {
+            const stored = reader.readStringWithLength();
+            partialPsbtBase64 = stored.length > 0 ? stored : undefined;
+        }
+
         return {
             header,
             baseParams,
@@ -138,6 +148,7 @@ export class TransactionSerializer {
             signerMappings,
             typeSpecificData,
             precomputedData,
+            ...(partialPsbtBase64 !== undefined ? { partialPsbtBase64 } : {}),
         };
     }
 

--- a/src/transaction/offline/interfaces/ISerializableState.ts
+++ b/src/transaction/offline/interfaces/ISerializableState.ts
@@ -3,9 +3,10 @@ import { ChainId } from '../../../network/ChainId.js';
 import type { TypeSpecificData } from './ITypeSpecificData.js';
 
 /**
- * Format version for serialization compatibility
+ * Format version for serialization compatibility.
+ * v2 adds the optional `partialPsbtBase64` field on the top-level state.
  */
-export const SERIALIZATION_FORMAT_VERSION = 1;
+export const SERIALIZATION_FORMAT_VERSION = 2;
 
 /**
  * Magic byte for identifying serialized transaction state
@@ -138,4 +139,11 @@ export interface ISerializableTransactionState {
     readonly typeSpecificData: TypeSpecificData;
     /** Pre-computed data for deterministic rebuild */
     readonly precomputedData: PrecomputedData;
+    /**
+     * Partial PSBT (base64) carrying signatures collected so far.
+     * Used by collaborative flows like CSV multisig where multiple cosigners
+     * accumulate signatures across hops before finalization.
+     * Only present once at least one signing hop has run.
+     */
+    readonly partialPsbtBase64?: string;
 }

--- a/src/transaction/shared/TweakedTransaction.ts
+++ b/src/transaction/shared/TweakedTransaction.ts
@@ -769,11 +769,27 @@ export abstract class TweakedTransaction extends Logger implements Disposable {
             }
         }
 
+        let allFinalized = true;
         for (let i = 0; i < transaction.data.inputs.length; i++) {
-            transaction.finalizeInput(i, this.customFinalizerP2SH.bind(this) as FinalScriptsFunc);
+            try {
+                transaction.finalizeInput(
+                    i,
+                    this.customFinalizerP2SH.bind(this) as FinalScriptsFunc,
+                );
+            } catch (e) {
+                // CSV multisig inputs may legitimately be below threshold during
+                // a collaborative signing hop. Leave them unfinalized so the
+                // partial PSBT can travel to the next cosigner.
+                if (this.csvMultisigInputs.has(i)) {
+                    allFinalized = false;
+                    continue;
+                }
+
+                throw e;
+            }
         }
 
-        this.finalized = true;
+        this.finalized = allFinalized;
     }
 
     /**
@@ -1509,12 +1525,24 @@ export abstract class TweakedTransaction extends Logger implements Disposable {
         // then, we sign all the remaining inputs with the wallet signer.
         await signer.multiSignPsbt([transaction]);
 
-        // Then, we finalize every input.
+        let allFinalized = true;
         for (let i = 0; i < transaction.data.inputs.length; i++) {
-            transaction.finalizeInput(i, this.customFinalizerP2SH.bind(this) as FinalScriptsFunc);
+            try {
+                transaction.finalizeInput(
+                    i,
+                    this.customFinalizerP2SH.bind(this) as FinalScriptsFunc,
+                );
+            } catch (e) {
+                if (this.csvMultisigInputs.has(i)) {
+                    allFinalized = false;
+                    continue;
+                }
+
+                throw e;
+            }
         }
 
-        this.finalized = true;
+        this.finalized = allFinalized;
     }
 
     protected isCSVScript(decompiled: (number | Uint8Array)[]): boolean {

--- a/test/add-refund-output.test.ts
+++ b/test/add-refund-output.test.ts
@@ -52,6 +52,7 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
         feeRate?: number;
         feeUtxos?: UTXO[];
         autoAdjustAmount?: boolean;
+        debugFees?: boolean;
     }) {
         const utxo = createTaprootUtxo(taprootAddress, opts.utxoValue);
         return new FundingTransaction({
@@ -64,6 +65,7 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
             priorityFee: 0n,
             gasSatFee: 0n,
             mldsaSigner: null,
+            debugFees: !!opts.debugFees,
             ...(opts.feeUtxos !== undefined && { feeUtxos: opts.feeUtxos }),
             ...(opts.autoAdjustAmount !== undefined && { autoAdjustAmount: opts.autoAdjustAmount }),
         });
@@ -207,12 +209,12 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
     // ================================================================
     //  Tolerance: sendBack < 0 but totalInput > amountSpent
     // ================================================================
-    describe('tolerance ,  effective fee is positive but less than estimated', () => {
-        it('should succeed when amount is close to totalInput leaving a small effective fee', async () => {
+    describe('tolerance ,  effective fee is positive but is a little bit less than estimated UTXO available', () => {
+        it('should succeed when amount+fees is close to totalInput', async () => {
             const utxoValue = 100_000n;
             // Leave 200 sats for fees ,  less than the estimated fee at high rate
             // but totalInput > amountSpent so it's valid
-            const amount = utxoValue - 200n;
+            const amount = utxoValue - 1109n;
 
             const tx = buildFunding({ utxoValue, amount, feeRate: 10 });
 
@@ -223,20 +225,80 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
 
             // Verify fee is exactly the 200 sats leftover
             const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
-            expect(utxoValue - totalOut).toBe(200n);
+            expect(utxoValue - totalOut).toBe(1109n);
+            expect(tx.transactionFee).toBe(1109n);
         });
 
-        it('should succeed with very small leftover (1 sat) as long as totalInput > amountSpent', async () => {
+        // Const real fees = 555n, dust = 330n
+        const shouldSucceed: [
+            delta: bigint,
+            succeed: boolean,
+            overflow: bigint,
+            message: string,
+        ][] = [
+            [0n, false, 0n, 'amount equal utxoValue'],
+            [1n, false, 0n, 'amount equal utxoValue less 1'],
+
+            // Check fees bondary
+            [553n, false, 0n, 'amount equal utxoValue less 553 (real fees - 2)'],
+            [554n, true, 0n, 'amount equal utxoValue less 554 (real fees - 1)'],
+            [555n, true, 0n, 'amount equal utxoValue less 555 (real fees)'],
+            [556n, true, 0n, 'amount equal utxoValue less 556 (real fees + 1)'],
+
+            // Check fees+dust bondaries
+            [555n + 329n, true, 0n, 'amount equal utxoValue less 884 (real fees + dust - 1)'],
+            [555n + 330n, true, 0n, 'amount equal utxoValue less 885 (real fees + dust)'],
+            [555n + 331n, true, 0n, 'amount equal utxoValue less 886 (real fees + dust + 1)'],
+
+            // If there is really a refund, a refund output section will be added
+            // to the tx, with a vbsize of 43 vbytes * 5 feeRate --> 215...
+            // Check the new fees+refund_section+dust boundaries
+            [
+                555n + 43n * 5n + 329n,
+                true,
+                0n,
+                'amount equal utxoValue less 1109 (real fees + refund + dust - 1)',
+            ],
+            [
+                555n + 43n * 5n + 330n,
+                true,
+                330n,
+                'amount equal utxoValue less 1110 (real fees + refund + dust)',
+            ],
+            [
+                555n + 43n * 5n + 331n,
+                true,
+                331n,
+                'amount equal utxoValue less 1111 (real fees + refund + dust + 1)',
+            ],
+        ];
+        it('should succeed with very small diff from calculated fees (1 sat)', async () => {
             const utxoValue = 100_000n;
-            const amount = utxoValue - 1n;
 
-            const tx = buildFunding({ utxoValue, amount, feeRate: 5 });
+            let tx: FundingTransaction | undefined = undefined;
+            for (const [delta, shouldSuccess, overflow, message] of shouldSucceed) {
+                let succeed = false;
+                try {
+                    const amount = utxoValue - delta;
 
-            const signed = await tx.signTransaction();
-            expect(signed.ins.length).toBeGreaterThan(0);
+                    tx = buildFunding({ utxoValue, amount, feeRate: 5, debugFees: false });
 
-            const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
-            expect(utxoValue - totalOut).toBe(1n);
+                    const signed = await tx.signTransaction();
+                    expect(signed.ins.length).toBeGreaterThan(0);
+
+                    const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
+
+                    //console.log('DELTA', utxoValue, totalOut, delta, overflow, tx.estimatedFees, tx.overflowFees,);
+                    expect(utxoValue - totalOut).toBe(delta - overflow);
+                    succeed = true;
+                } catch (e) {
+                    //console.log('E', e);
+                    succeed = false;
+                }
+
+                expect(succeed, message).toBe(shouldSuccess);
+                expect(tx?.overflowFees, message).toBe(overflow);
+            }
         });
     });
 

--- a/test/add-refund-output.test.ts
+++ b/test/add-refund-output.test.ts
@@ -205,38 +205,29 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
     });
 
     // ================================================================
-    //  Tolerance: sendBack < 0 but totalInput > amountSpent
+    //  Fee underpayment guard: leftover absorbed into fee must still meet feeRate
     // ================================================================
-    describe('tolerance ,  effective fee is positive but less than estimated', () => {
-        it('should succeed when amount is close to totalInput leaving a small effective fee', async () => {
+    describe('fee underpayment guard', () => {
+        it('should throw when leftover would underpay feeRate (200 sats at feeRate=10)', async () => {
             const utxoValue = 100_000n;
-            // Leave 200 sats for fees ,  less than the estimated fee at high rate
-            // but totalInput > amountSpent so it's valid
             const amount = utxoValue - 200n;
 
             const tx = buildFunding({ utxoValue, amount, feeRate: 10 });
 
-            const signed = await tx.signTransaction();
-
-            expect(signed.ins.length).toBeGreaterThan(0);
-            expect(signed.outs.length).toBeGreaterThan(0);
-
-            // Verify fee is exactly the 200 sats leftover
-            const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
-            expect(utxoValue - totalOut).toBe(200n);
+            await expect(tx.signTransaction()).rejects.toThrow(
+                /Insufficient funds for fee/,
+            );
         });
 
-        it('should succeed with very small leftover (1 sat) as long as totalInput > amountSpent', async () => {
+        it('should throw when leftover is a token amount (1 sat) far below feeRate', async () => {
             const utxoValue = 100_000n;
             const amount = utxoValue - 1n;
 
             const tx = buildFunding({ utxoValue, amount, feeRate: 5 });
 
-            const signed = await tx.signTransaction();
-            expect(signed.ins.length).toBeGreaterThan(0);
-
-            const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
-            expect(utxoValue - totalOut).toBe(1n);
+            await expect(tx.signTransaction()).rejects.toThrow(
+                /Insufficient funds for fee/,
+            );
         });
     });
 
@@ -532,6 +523,79 @@ describe('addRefundOutput ,  deterministic fee estimation', () => {
 
             // Should still have a change output
             expect(signed.outs.length).toBeGreaterThanOrEqual(2);
+        });
+
+        // Regression: trigger must be `amount + fee > totalInput`, not just
+        // `amount >= totalInput`. Previously, an amount one sat below the total
+        // would slip past auto-adjust and silently produce a 1-sat fee instead
+        // of the fee implied by feeRate.
+        it('should auto-adjust when amount + fee exceeds total (amount alone fits)', async () => {
+            const utxoValue = 100_000n;
+            const amount = 99_999n; // 1 sat below total, fee at feeRate=2 will not fit
+            const feeRate = 2;
+
+            const tx = buildFunding({
+                utxoValue,
+                amount,
+                autoAdjustAmount: true,
+                feeRate,
+            });
+
+            const signed = await tx.signTransaction();
+
+            const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
+            const fee = utxoValue - totalOut;
+
+            // Primary output must have been trimmed to make room for the fee.
+            const primaryOut = signed.outs.find((o) => BigInt(o.value) > 0n);
+            expect(primaryOut).toBeDefined();
+            expect(BigInt(primaryOut!.value)).toBeLessThan(amount);
+
+            // Paid fee must reflect feeRate, not be silently shaved to a token amount.
+            // A taproot input + taproot output is ~110-150 vbytes, so fee >= ~100 sat at feeRate=2.
+            expect(fee).toBeGreaterThanOrEqual(100n);
+
+            // Nothing lost: total out + fee == total in.
+            expect(totalOut + fee).toBe(utxoValue);
+
+            // No change output — trim consumes all input.
+            expect(signed.outs.length).toBe(1);
+        });
+
+        it('should auto-adjust across a range of near-total amounts', async () => {
+            const utxoValue = 100_000n;
+            const feeRate = 2;
+
+            for (const amount of [99_999n, 99_950n, 99_900n, 99_850n]) {
+                const tx = buildFunding({
+                    utxoValue,
+                    amount,
+                    autoAdjustAmount: true,
+                    feeRate,
+                });
+
+                const signed = await tx.signTransaction();
+                const totalOut = signed.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
+                const fee = utxoValue - totalOut;
+
+                expect(totalOut).toBeLessThan(amount);
+                expect(fee).toBeGreaterThanOrEqual(100n);
+                expect(totalOut + fee).toBe(utxoValue);
+            }
+        });
+
+        it('should throw when amount + fee exceeds total and autoAdjust is false', async () => {
+            const utxoValue = 100_000n;
+            const amount = 99_999n;
+
+            const tx = buildFunding({
+                utxoValue,
+                amount,
+                autoAdjustAmount: false,
+                feeRate: 2,
+            });
+
+            await expect(tx.signTransaction()).rejects.toThrow(/[Ii]nsufficient funds/);
         });
     });
 });

--- a/test/csv-multisig-offline-edges.test.ts
+++ b/test/csv-multisig-offline-edges.test.ts
@@ -1,0 +1,293 @@
+/**
+ * csv-multisig-offline-edges.test.ts
+ *
+ * Edge cases for the OfflineTransactionManager CSV multisig API:
+ *   - csvMultisigGetStatus standalone
+ *   - csvMultisigFinalize error paths
+ *   - addCSVMultisigSignature idempotency + non-cosigner no-op on first hop
+ *   - Serializer v2 round-trip of partialPsbtBase64
+ *   - signPSBT returns a partial PSBT for under-threshold CSV inputs
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+    crypto as bitCrypto,
+    networks,
+    payments,
+    Psbt,
+    toHex,
+    toXOnly,
+    type XOnlyPublicKey,
+} from '@btc-vision/bitcoin';
+import { type UniversalSigner } from '@btc-vision/ecpair';
+import type { UTXO } from '../build/opnet.js';
+import {
+    CSVMultisigProvider,
+    EcKeyPair,
+    FundingTransaction,
+    OfflineTransactionManager,
+    TransactionBuilder,
+    TransactionSerializer,
+} from '../build/opnet.js';
+
+const network = networks.regtest;
+
+function makeSigner(seed: string): UniversalSigner {
+    return EcKeyPair.fromPrivateKey(
+        bitCrypto.sha256(new TextEncoder().encode(seed)),
+        network,
+    );
+}
+
+function buildAddr(signers: UniversalSigner[], csvBlocks: number, threshold: number) {
+    const pubkeys = signers.map((s) => toXOnly(s.publicKey) as XOnlyPublicKey);
+    return CSVMultisigProvider.generateAddress({ pubkeys, threshold, csvBlocks }, network);
+}
+
+function makeUtxo(
+    addr: ReturnType<typeof buildAddr>,
+    value: bigint,
+    txid: string = '22'.repeat(32),
+): UTXO {
+    return {
+        transactionId: txid,
+        outputIndex: 0,
+        value,
+        scriptPubKey: {
+            hex: toHex(addr.scriptPubKey),
+            address: addr.address,
+        },
+        witnessScript: addr.tapscript,
+    };
+}
+
+function fundingState(
+    addr: ReturnType<typeof buildAddr>,
+    utxo: UTXO,
+    placeholderSigner: UniversalSigner,
+): string {
+    const recipient = payments.p2tr({
+        internalPubkey: toXOnly(placeholderSigner.publicKey) as XOnlyPublicKey,
+        network,
+    }).address as string;
+
+    return OfflineTransactionManager.exportFunding({
+        signer: placeholderSigner,
+        mldsaSigner: null,
+        network,
+        utxos: [utxo],
+        to: recipient,
+        amount: TransactionBuilder.MINIMUM_DUST,
+        feeRate: 1,
+        priorityFee: 0n,
+        gasSatFee: 0n,
+    });
+}
+
+describe('OfflineTransactionManager CSV multisig — edges', () => {
+    let signerA: UniversalSigner;
+    let signerB: UniversalSigner;
+    let signerC: UniversalSigner;
+    let signerD: UniversalSigner; // never a cosigner anywhere
+
+    beforeAll(() => {
+        signerA = makeSigner('edges-A');
+        signerB = makeSigner('edges-B');
+        signerC = makeSigner('edges-C');
+        signerD = makeSigner('edges-D');
+    });
+
+    // ----------------------------------------------------------------
+    // csvMultisigGetStatus
+    // ----------------------------------------------------------------
+    describe('csvMultisigGetStatus', () => {
+        it('returns [] when no partial PSBT has been produced yet', () => {
+            const addr = buildAddr([signerA, signerB], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            expect(OfflineTransactionManager.csvMultisigGetStatus(state)).toEqual([]);
+        });
+
+        it('reflects the same status as the hop result after addCSVMultisigSignature', async () => {
+            const addr = buildAddr([signerA, signerB, signerC], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+            const direct = OfflineTransactionManager.csvMultisigGetStatus(hop1.state);
+
+            expect(direct).toEqual(hop1.perInput);
+            expect(direct[0]!.collected).toBe(1);
+            expect(direct[0]!.required).toBe(2);
+        });
+
+        it('reports collected === threshold for finalized inputs (threshold=1 single hop)', async () => {
+            const addr = buildAddr([signerA], 3, 1);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+
+            const status = OfflineTransactionManager.csvMultisigGetStatus(hop1.state);
+            expect(status).toHaveLength(1);
+            expect(status[0]!.required).toBe(1);
+            expect(status[0]!.collected).toBe(1);
+        });
+    });
+
+    // ----------------------------------------------------------------
+    // csvMultisigFinalize error paths
+    // ----------------------------------------------------------------
+    describe('csvMultisigFinalize', () => {
+        it('throws when no partial PSBT exists in state', () => {
+            const addr = buildAddr([signerA, signerB], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            expect(() => OfflineTransactionManager.csvMultisigFinalize(state)).toThrow(
+                /No partial PSBT/i,
+            );
+        });
+
+        it('throws when the partial PSBT is below threshold', async () => {
+            const addr = buildAddr([signerA, signerB, signerC], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+            expect(hop1.final).toBe(false);
+
+            expect(() => OfflineTransactionManager.csvMultisigFinalize(hop1.state)).toThrow(
+                /needs 2 signatures, got 1/,
+            );
+        });
+    });
+
+    // ----------------------------------------------------------------
+    // addCSVMultisigSignature edge cases
+    // ----------------------------------------------------------------
+    describe('addCSVMultisigSignature', () => {
+        it('is idempotent — re-signing with the same cosigner does not double-count', async () => {
+            const addr = buildAddr([signerA, signerB, signerC], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+            expect(hop1.perInput[0]!.collected).toBe(1);
+
+            const hop2 = await OfflineTransactionManager.addCSVMultisigSignature(
+                hop1.state,
+                signerA,
+            );
+            expect(hop2.perInput[0]!.collected).toBe(1);
+            expect(hop2.final).toBe(false);
+        });
+
+        it('non-cosigner on a non-first hop leaves the partial PSBT unchanged', async () => {
+            const addr = buildAddr([signerA, signerB], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+            expect(hop1.perInput[0]!.collected).toBe(1);
+
+            // signerD is in neither the tapscript nor the original signer slot
+            const hop2 = await OfflineTransactionManager.addCSVMultisigSignature(
+                hop1.state,
+                signerD,
+            );
+            expect(hop2.perInput[0]!.collected).toBe(1);
+            expect(hop2.final).toBe(false);
+        });
+
+        it('reaches threshold across three distinct cosigners (2-of-3 with C+B)', async () => {
+            const addr = buildAddr([signerA, signerB, signerC], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            // Placeholder signer is A — but the actual cosigners are C then B.
+            const state = fundingState(addr, utxo, signerA);
+
+            // Build PSBT using A as the placeholder for the first hop;
+            // immediately overlay C's signature in a second hop.
+            const hopA = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+            expect(hopA.perInput[0]!.collected).toBe(1);
+
+            const hopC = await OfflineTransactionManager.addCSVMultisigSignature(
+                hopA.state,
+                signerC,
+            );
+            expect(hopC.perInput[0]!.collected).toBe(2);
+            expect(hopC.final).toBe(true);
+
+            // Finalization succeeds even though signerB never participated.
+            const rawTxHex = OfflineTransactionManager.csvMultisigFinalize(hopC.state);
+            expect(rawTxHex).toMatch(/^[0-9a-f]+$/);
+        });
+    });
+
+    // ----------------------------------------------------------------
+    // Serializer v2 round-trip
+    // ----------------------------------------------------------------
+    describe('serializer v2 — partialPsbtBase64 round-trip', () => {
+        it('omits the field on a freshly exported state', () => {
+            const addr = buildAddr([signerA, signerB], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const decoded = TransactionSerializer.fromBase64(state);
+            expect(decoded.partialPsbtBase64).toBeUndefined();
+        });
+
+        it('round-trips the partial PSBT verbatim after a signing hop', async () => {
+            const addr = buildAddr([signerA, signerB], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const state = fundingState(addr, utxo, signerA);
+
+            const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(state, signerA);
+
+            const decoded = TransactionSerializer.fromBase64(hop1.state);
+            expect(decoded.partialPsbtBase64).toBeDefined();
+
+            // Sanity: the carried PSBT actually parses and has one tapScriptSig.
+            const psbt = Psbt.fromBase64(decoded.partialPsbtBase64!, { network });
+            expect(psbt.data.inputs[0]!.tapScriptSig).toHaveLength(1);
+
+            // Round-trip via toBase64 yields a byte-identical payload.
+            const reEncoded = TransactionSerializer.toBase64(decoded);
+            expect(reEncoded).toBe(hop1.state);
+        });
+    });
+
+    // ----------------------------------------------------------------
+    // signPSBT semantic shift: returns the (possibly partial) PSBT
+    // ----------------------------------------------------------------
+    describe('TransactionBuilder.signPSBT — partial PSBT semantics', () => {
+        it('returns a PSBT with the tapScriptSig but no finalScriptWitness for under-threshold CSV input', async () => {
+            const addr = buildAddr([signerA, signerB, signerC], 5, 2);
+            const utxo = makeUtxo(addr, 200_000n);
+            const recipient = payments.p2tr({
+                internalPubkey: toXOnly(signerA.publicKey) as XOnlyPublicKey,
+                network,
+            }).address as string;
+
+            const tx = new FundingTransaction({
+                signer: signerA,
+                mldsaSigner: null,
+                network,
+                utxos: [utxo],
+                to: recipient,
+                amount: TransactionBuilder.MINIMUM_DUST,
+                feeRate: 1,
+                priorityFee: 0n,
+                gasSatFee: 0n,
+            });
+
+            const psbt = await tx.signPSBT();
+            const input = psbt.data.inputs[0]!;
+
+            expect(input.tapScriptSig).toBeDefined();
+            expect(input.tapScriptSig).toHaveLength(1);
+            expect(input.finalScriptWitness).toBeUndefined();
+        });
+    });
+});

--- a/test/csv-multisig-offline.test.ts
+++ b/test/csv-multisig-offline.test.ts
@@ -1,0 +1,202 @@
+/**
+ * csv-multisig-offline.test.ts
+ *
+ * Library-native multi-signer flow for spending CSV multisig UTXOs using
+ * OfflineTransactionManager — the documented offline signing API. No raw
+ * @btc-vision/bitcoin Psbt construction.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+    crypto as bitCrypto,
+    networks,
+    payments,
+    toHex,
+    toXOnly,
+    type XOnlyPublicKey,
+} from '@btc-vision/bitcoin';
+import { type UniversalSigner } from '@btc-vision/ecpair';
+import type { UTXO } from '../build/opnet.js';
+import {
+    CSVMultisigProvider,
+    EcKeyPair,
+    OfflineTransactionManager,
+    TransactionBuilder,
+} from '../build/opnet.js';
+
+const network = networks.regtest;
+
+function makeSigner(seed: string): UniversalSigner {
+    return EcKeyPair.fromPrivateKey(
+        bitCrypto.sha256(new TextEncoder().encode(seed)),
+        network,
+    );
+}
+
+function buildAddr(signers: UniversalSigner[], csvBlocks: number, threshold: number) {
+    const pubkeys = signers.map((s) => toXOnly(s.publicKey) as XOnlyPublicKey);
+    return CSVMultisigProvider.generateAddress({ pubkeys, threshold, csvBlocks }, network);
+}
+
+function makeUtxo(addr: ReturnType<typeof buildAddr>, value: bigint): UTXO {
+    return {
+        transactionId: '11'.repeat(32),
+        outputIndex: 0,
+        value,
+        scriptPubKey: {
+            hex: toHex(addr.scriptPubKey),
+            address: addr.address,
+        },
+        witnessScript: addr.tapscript,
+    };
+}
+
+describe('CSV multisig offline multi-signer flow', () => {
+    let signerA: UniversalSigner;
+    let signerB: UniversalSigner;
+    let signerC: UniversalSigner;
+
+    beforeAll(() => {
+        signerA = makeSigner('offline-A');
+        signerB = makeSigner('offline-B');
+        signerC = makeSigner('offline-C');
+    });
+
+    it('2-of-3 signers produce a broadcastable tx through OfflineTransactionManager', async () => {
+        const addr = buildAddr([signerA, signerB, signerC], 10, 2);
+        const utxo = makeUtxo(addr, 1_000_000n);
+        const recipient = payments.p2tr({
+            internalPubkey: toXOnly(signerA.publicKey) as XOnlyPublicKey,
+            network,
+        }).address as string;
+
+        // --- Coordinator (online): export funding state ---
+        const initialState = OfflineTransactionManager.exportFunding({
+            signer: signerA, // placeholder; real signer supplied per-hop
+            mldsaSigner: null,
+            network,
+            utxos: [utxo],
+            to: recipient,
+            amount: TransactionBuilder.MINIMUM_DUST,
+            feeRate: 1,
+            priorityFee: 0n,
+            gasSatFee: 0n,
+        });
+
+        // Before any signing, there's no partial PSBT yet.
+        expect(OfflineTransactionManager.csvMultisigGetStatus(initialState)).toEqual([]);
+
+        // --- Hop 1: signer A adds signature (offline env) ---
+        const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(
+            initialState,
+            signerA,
+        );
+        expect(hop1.final).toBe(false);
+        expect(hop1.perInput).toHaveLength(1);
+        expect(hop1.perInput[0]!.required).toBe(2);
+        expect(hop1.perInput[0]!.collected).toBe(1);
+        expect(hop1.perInput[0]!.signers).toContain(toHex(toXOnly(signerA.publicKey)));
+
+        // --- Hop 2: signer B adds signature (different offline env) ---
+        const hop2 = await OfflineTransactionManager.addCSVMultisigSignature(
+            hop1.state,
+            signerB,
+        );
+        expect(hop2.final).toBe(true);
+        expect(hop2.perInput[0]!.collected).toBe(2);
+        expect(new Set(hop2.perInput[0]!.signers)).toEqual(
+            new Set([
+                toHex(toXOnly(signerA.publicKey)),
+                toHex(toXOnly(signerB.publicKey)),
+            ]),
+        );
+
+        // --- Finalize + extract (anyone, no key material required) ---
+        const rawTxHex = OfflineTransactionManager.csvMultisigFinalize(hop2.state);
+        expect(rawTxHex).toMatch(/^[0-9a-f]+$/);
+
+        // Sanity: the extracted tx has the expected witness shape and CSV sequence.
+        const state = OfflineTransactionManager.inspect(hop2.state);
+        expect(state.partialPsbtBase64).toBeDefined();
+    });
+
+    it('signer pubkey not in the tapscript is a no-op', async () => {
+        const addr = buildAddr([signerA, signerB], 5, 2);
+        const utxo = makeUtxo(addr, 500_000n);
+        const recipient = payments.p2tr({
+            internalPubkey: toXOnly(signerA.publicKey) as XOnlyPublicKey,
+            network,
+        }).address as string;
+
+        const initialState = OfflineTransactionManager.exportFunding({
+            signer: signerA,
+            mldsaSigner: null,
+            network,
+            utxos: [utxo],
+            to: recipient,
+            amount: TransactionBuilder.MINIMUM_DUST,
+            feeRate: 1,
+            priorityFee: 0n,
+            gasSatFee: 0n,
+        });
+
+        const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(
+            initialState,
+            signerA,
+        );
+        expect(hop1.perInput[0]!.collected).toBe(1);
+
+        // signerC is not in this 2-of-2 tapscript.
+        const hop2 = await OfflineTransactionManager.addCSVMultisigSignature(
+            hop1.state,
+            signerC,
+        );
+        expect(hop2.perInput[0]!.collected).toBe(1);
+        expect(hop2.final).toBe(false);
+
+        // Finalize should throw because we're still below threshold.
+        expect(() => OfflineTransactionManager.csvMultisigFinalize(hop2.state)).toThrow(
+            /needs 2 signatures, got 1/,
+        );
+
+        // Now add the real second signer and finalize.
+        const hop3 = await OfflineTransactionManager.addCSVMultisigSignature(
+            hop2.state,
+            signerB,
+        );
+        expect(hop3.final).toBe(true);
+
+        const rawTxHex = OfflineTransactionManager.csvMultisigFinalize(hop3.state);
+        expect(rawTxHex).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('threshold = 1 finalizes in a single hop and emits a ready-to-broadcast tx', async () => {
+        const addr = buildAddr([signerA], 3, 1);
+        const utxo = makeUtxo(addr, 500_000n);
+        const recipient = payments.p2tr({
+            internalPubkey: toXOnly(signerA.publicKey) as XOnlyPublicKey,
+            network,
+        }).address as string;
+
+        const initialState = OfflineTransactionManager.exportFunding({
+            signer: signerA,
+            mldsaSigner: null,
+            network,
+            utxos: [utxo],
+            to: recipient,
+            amount: TransactionBuilder.MINIMUM_DUST,
+            feeRate: 1,
+            priorityFee: 0n,
+            gasSatFee: 0n,
+        });
+
+        const hop1 = await OfflineTransactionManager.addCSVMultisigSignature(
+            initialState,
+            signerA,
+        );
+        expect(hop1.final).toBe(true);
+
+        const rawTxHex = OfflineTransactionManager.csvMultisigFinalize(hop1.state);
+        expect(rawTxHex).toMatch(/^[0-9a-f]+$/);
+    });
+});

--- a/test/transaction-builders.test.ts
+++ b/test/transaction-builders.test.ts
@@ -177,16 +177,13 @@ describe('Transaction Builders - End-to-End', () => {
             await expect(tx.signTransaction()).rejects.toThrow(/Insufficient funds/);
         });
 
-        it('should tolerate small fee estimation shortfalls when effective fee is still positive', async () => {
-            // When amount is close to totalInputAmount but leaves some sats for
-            // fees, the estimated fee may exceed what's available. As long as the
-            // effective fee (totalInputAmount - amountSpent) is positive, the
-            // transaction should succeed ,  the fee is just lower than estimated.
+        it('should throw when leftover fee would underpay feeRate (no autoAdjust)', async () => {
+            // When amount is close to totalInputAmount but leaves less than the
+            // fee implied by feeRate, the transaction must NOT broadcast with an
+            // underpaid fee. Callers wanting send-max behavior must opt in via
+            // autoAdjustAmount=true.
             const utxoValue = 100_000n;
             const utxo = createTaprootUtxo(taprootAddress, utxoValue);
-
-            // Leave 200 sats for fees ,  less than the estimated ~77 sats/vB * ~77 vB
-            // but still a positive effective fee
             const amount = utxoValue - 200n;
 
             const tx = new FundingTransaction({
@@ -195,21 +192,15 @@ describe('Transaction Builders - End-to-End', () => {
                 utxos: [utxo],
                 to: taprootAddress,
                 amount,
-                feeRate: 10, // high fee rate means estimated fee > 200, but effective fee = 200
+                feeRate: 10,
                 priorityFee: 0n,
                 gasSatFee: 0n,
                 mldsaSigner: null,
             });
 
-            // Should NOT throw ,  effective fee is 200 sats (positive), even though
-            // it's less than the estimated fee at feeRate=10
-            const signed = await tx.signTransaction();
-            expect(signed.ins.length).toBeGreaterThan(0);
-            expect(signed.outs.length).toBeGreaterThan(0);
-
-            // Verify fee is exactly what was left over
-            const totalOutputValue = signed.outs.reduce((sum, out) => sum + BigInt(out.value), 0n);
-            expect(utxoValue - totalOutputValue).toBe(200n);
+            await expect(tx.signTransaction()).rejects.toThrow(
+                /Insufficient funds for fee/,
+            );
         });
 
         it('should auto-adjust amount when amount equals total UTXO value with autoAdjustAmount', async () => {

--- a/test/transaction-builders.test.ts
+++ b/test/transaction-builders.test.ts
@@ -177,7 +177,7 @@ describe('Transaction Builders - End-to-End', () => {
             await expect(tx.signTransaction()).rejects.toThrow(/Insufficient funds/);
         });
 
-        it('should tolerate small fee estimation shortfalls when effective fee is still positive', async () => {
+        it('should tolerate small fee estimation shortfalls when amount + effective fee is near to input utxos', async () => {
             // When amount is close to totalInputAmount but leaves some sats for
             // fees, the estimated fee may exceed what's available. As long as the
             // effective fee (totalInputAmount - amountSpent) is positive, the
@@ -187,7 +187,7 @@ describe('Transaction Builders - End-to-End', () => {
 
             // Leave 200 sats for fees ,  less than the estimated ~77 sats/vB * ~77 vB
             // but still a positive effective fee
-            const amount = utxoValue - 200n;
+            const amount = utxoValue - 1110n;
 
             const tx = new FundingTransaction({
                 signer,
@@ -209,7 +209,7 @@ describe('Transaction Builders - End-to-End', () => {
 
             // Verify fee is exactly what was left over
             const totalOutputValue = signed.outs.reduce((sum, out) => sum + BigInt(out.value), 0n);
-            expect(utxoValue - totalOutputValue).toBe(200n);
+            expect(utxoValue - totalOutputValue).toBe(1110n);
         });
 
         it('should auto-adjust amount when amount equals total UTXO value with autoAdjustAmount', async () => {
@@ -246,6 +246,48 @@ describe('Transaction Builders - End-to-End', () => {
             // Allow small variance due to fee estimation iterations
             expect(fee).toBeGreaterThan(0n);
             expect(fee).toBeLessThanOrEqual(expectedFee + 10n);
+        });
+
+        it('should auto-adjust amount when amount + fees is higher than total UTXO value with autoAdjustAmount', async () => {
+            const amount = 100_000n;
+            const utxoValue = 100_100n; // Only 100 sats available for fees
+            const utxo = createTaprootUtxo(taprootAddress, utxoValue);
+            const feeRate = 2;
+
+            const tx = new FundingTransaction({
+                signer,
+                network,
+                utxos: [utxo],
+                to: taprootAddress,
+                amount: amount,
+                autoAdjustAmount: true,
+                feeRate,
+                priorityFee: 0n,
+                gasSatFee: 0n,
+                mldsaSigner: null,
+            });
+
+            const signed = await tx.signTransaction();
+
+            expect(signed.ins.length).toBeGreaterThan(0);
+            expect(signed.outs.length).toBeGreaterThan(0);
+            expect(signed.toHex()).toBeTruthy();
+
+            // Calculate total ouput for following tests
+            const totalOutputValue = signed.outs.reduce((sum, out) => sum + BigInt(out.value), 0n);
+
+            // The fee should be roughly feeRate * virtualSize
+            const fee = utxoValue - totalOutputValue;
+            const expectedFee = BigInt(Math.ceil(feeRate * signed.virtualSize()));
+            // Allow small variance due to fee estimation iterations
+            expect(fee).toBeGreaterThan(0n);
+            expect(fee).toBeGreaterThanOrEqual(expectedFee - 10n);
+            expect(fee).toBeLessThanOrEqual(expectedFee + 10n);
+
+            // The total output value should be less than utxoValue (fees deducted)
+            const expectedAmount = utxoValue - expectedFee;
+            expect(totalOutputValue).toBeLessThan(expectedAmount + 10n);
+            expect(totalOutputValue).toBeGreaterThan(expectedAmount - 10n);
         });
 
         it('should not adjust amount when autoAdjustAmount is true but amount < totalInputAmount', async () => {


### PR DESCRIPTION
## Description
autoAdjustAmount now, if enabled, adjust amount each time there is not enough UTXOs to cover amount + fees.
if there is a small difference between input amount and amount + fees (1 sat, set via TOLERENCE const), lower the fees.
will now throw if not enough UTXO to cover amount + fees instead of reducing fees up to 1 sat.  May be a breacking change if not managed correctly on client side.

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests
- [ ] `npm install` completes without errors
- [X] `npm test` passes all tests

### Code Quality
- [ ] Code follows the project's coding standards
- [X] No new compiler warnings introduced
- [ ] Error handling is appropriate
- [ ] SafeMath used for all arithmetic operations

### Documentation
- [ ] Code comments added for complex logic
- [ ] Public APIs are documented
- [ ] README updated (if applicable)

### Security
- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] No floating-point arithmetic used

## Testing
Tested via vitest and unit tests.

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

---
By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
