### PR TITLE
Fix feeUTXOs calculation when decoding tx fees

### DIFF
--- a/src/transaction/TransactionFactory.ts
+++ b/src/transaction/TransactionFactory.ts
@@ -556,7 +556,7 @@ export class TransactionFactory {
             estimatedFees: resp.estimatedFees,
             tx: resp.tx.toHex(),
             nextUTXOs: this.getAllNewUTXOs(resp.original, resp.tx, parameters.from),
-            inputUtxos: parameters.utxos,
+            inputUtxos: [...parameters.utxos, ...(parameters.feeUtxos ?? [])],
         };
     }
 


### PR DESCRIPTION
## Description
Fix bad fee calculation on wallet-mobile/wallet extension when using the feeUTXO parameter of IFundingTransaction.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests
- [X] `npm install` completes without errors
- [X] `npm test` passes all tests

### Code Quality
- [ ] Code follows the project's coding standards
- [ ] No new compiler warnings introduced
- [ ] Error handling is appropriate
- [ ] SafeMath used for all arithmetic operations

### Documentation
- [ ] Code comments added for complex logic
- [ ] Public APIs are documented
- [ ] README updated (if applicable)

### Security
- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] No floating-point arithmetic used

## Testing
Tested manually in wallet-mobile and wallet extension

## Related Issues
<!-- Link any related issues: Fixes #123, Relates to #456 -->

---
By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
